### PR TITLE
Add ability to initiate bug reporting flow with image

### DIFF
--- a/BugBattle/Classes/BugBattleCore.h
+++ b/BugBattle/Classes/BugBattleCore.h
@@ -40,6 +40,14 @@ typedef enum activationMethodTypes { NONE, SHAKE } BugBattleActivationMethod;
 + (void)startBugReporting;
 
 /**
+ * Manually start the bug reporting workflow, using a custom screenshot (rather than
+ * automatically capturing one). This is used, when you use the activation method "NONE".
+ * @author BugBattle
+ *
+ */
++ (void)startBugReportingWithScreenshot: (UIImage *)screenshot;
+
+/**
  * Attach custom data, which can be view in the BugBattle dashboard.
  * @author BugBattle
  *

--- a/BugBattle/Classes/BugBattleCore.m
+++ b/BugBattle/Classes/BugBattleCore.m
@@ -125,14 +125,20 @@
  Starts the bug reporting flow, when a SDK key has been assigned.
  */
 + (void)startBugReporting {
+    UIImage * screenshot = [BugBattle.sharedInstance captureScreen];
+    [self startBugReportingWithScreenshot: screenshot];
+}
+
+/*
+ Starts the bug reporting flow, when a SDK key has been assigned.
+ */
++ (void)startBugReportingWithScreenshot:(UIImage *)screenshot {
     if (BugBattle.sharedInstance.token.length > 0) {
         // Stop screen capturung
         [BugBattle.sharedInstance.stepsToReproduceTimer invalidate];
         
         UIStoryboard* storyboard = [UIStoryboard storyboardWithName: @"BugBattleStoryboard" bundle: [BugBattle frameworkBundle]];
         BugBattleImageEditorViewController *bugBattleImageEditor = [storyboard instantiateViewControllerWithIdentifier: @"BugBattleImageEditorViewController"];
-        
-        UIImage * screenshot = [BugBattle.sharedInstance captureScreen];
         
         UINavigationController * navController = [[UINavigationController alloc] initWithRootViewController: bugBattleImageEditor];
         navController.navigationBar.barStyle = UIBarStyleBlack;


### PR DESCRIPTION
In our app, we have an interface for sharing screenshots already (to facebook, instagram, etc).  We wanted to add the ability in our dev builds to use this same flow to report a bug. At this point, we already have a screenshot to share, so I needed a way to launch the BugBattle SDK with this screenshot.

